### PR TITLE
Corrected link to the GoSTRIPEs Github page.

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -10,7 +10,7 @@ called /scratch/TRYgoSTRIPES:
 
 ```bash
 cd
-git clone https://github.com/GoSTRIPES
+git clone https://github.com/BrendelGroup/GoSTRIPES
 cd /scratch/TRYgoSTRIPES
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ container. Please see the [HOWTO](./HOWTO.md) document for a worked example.
 
 ## Reference
 
-Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020)\ 
-Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv.\ 
+Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020) 
+Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv. 
 https://doi.org/10.1101/2020.01.16.905182. Submitted.
 
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ container. Please see the [HOWTO](./HOWTO.md) document for a worked example.
 
 ## Reference
 
-Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020) Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv. https://doi.org/10.1101/2020.01.16.905182. In Review.
+Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020) 
+Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv. 
+https://doi.org/10.1101/2020.01.16.905182. Submitted.
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -37,9 +37,7 @@ container. Please see the [HOWTO](./HOWTO.md) document for a worked example.
 
 ## Reference
 
-Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel, and Gabriel E. Zentner
-(2019) _Simple and efficient mapping of transcription start sites with STRIPE-seq._
-To be submitted.
+Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020) Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv. https://doi.org/10.1101/2020.01.16.905182. In Review.
 
 
 ## Contact

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ container. Please see the [HOWTO](./HOWTO.md) document for a worked example.
 
 ## Reference
 
-Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020) 
-Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv. 
+Robert A. Policastro, R. Taylor Raborn, Volker P. Brendel and Gabriel E. Zentner. (2020)\ 
+Simple and efficient mapping of transcription start sites with STRIPE-seq. biorXiv.\ 
 https://doi.org/10.1101/2020.01.16.905182. Submitted.
 
 


### PR DESCRIPTION
- the previous version lacked the correct Github url